### PR TITLE
Handle the case when the Content-Length  is repeated twice

### DIFF
--- a/src/ShiftIt.Unit.Tests/Helpers/HttpSample.cs
+++ b/src/ShiftIt.Unit.Tests/Helpers/HttpSample.cs
@@ -23,5 +23,10 @@ namespace ShiftIt.Unit.Tests.Helpers
 		{
 			return File.OpenRead(".\\Helpers\\"+f+".txt");
 		}
+
+		public static Stream WithDuplicatedHeaders()
+		{
+			return Sample("duplicated_headers");
+		}
 	}
 }

--- a/src/ShiftIt.Unit.Tests/Helpers/duplicated_headers.txt
+++ b/src/ShiftIt.Unit.Tests/Helpers/duplicated_headers.txt
@@ -1,0 +1,12 @@
+﻿HTTP/1.1 200 OK
+Date: Sun, 03 Feb 2013 13:19:56 GMT
+Server: Microsoft-IIS/6.0
+X-Powered-By: ASP.NET
+Pragma: no-cache
+Content-Length: 96
+Content-Type: text/html
+Expires: Sun, 03 Feb 2013 13:18:56 GMT
+Cache-control: no-store
+Content-Length: 96
+
+<html><head><title>A html page</title></head><body> <h1>Hi</h1><p>Hello there!</p></body></html>

--- a/src/ShiftIt.Unit.Tests/Http/Responses/WithDuplicatedHeaders.cs
+++ b/src/ShiftIt.Unit.Tests/Http/Responses/WithDuplicatedHeaders.cs
@@ -1,0 +1,64 @@
+﻿using System.IO;
+using NUnit.Framework;
+using ShiftIt.Http;
+using ShiftIt.Http.Internal;
+using ShiftIt.Unit.Tests.Helpers;
+
+namespace ShiftIt.Unit.Tests.Http.Responses
+{
+	[TestFixture]
+	public class WithDuplicatedHeaders
+	{
+		IHttpResponseParser _subject;
+		Stream _rawSample;
+		IHttpResponse _result;
+
+		[SetUp]
+		public void setup()
+		{
+			_rawSample = HttpSample.WithDuplicatedHeaders();
+			_subject = new HttpResponseParser();
+			_result = _subject.Parse(_rawSample);
+		}
+
+		[TearDown]
+		public void cleanup()
+		{
+			_result.Dispose();
+		}
+
+		[Test]
+		public void headers_are_marked_complete()
+		{
+			Assert.That(_result.HeadersComplete, Is.True);
+		}
+
+		[Test]
+		public void can_get_status_code_and_class()
+		{
+			Assert.That(_result.StatusCode, Is.EqualTo(200));
+			Assert.That(_result.StatusClass, Is.EqualTo(StatusClass.Success));
+		}
+
+		[Test]
+		public void http_headers_are_correct()
+		{
+			Assert.That(_result.Headers["Date"], Is.EqualTo("Sun, 03 Feb 2013 13:19:56 GMT"));
+			Assert.That(_result.Headers["Server"], Is.EqualTo("Microsoft-IIS/6.0"));
+			Assert.That(_result.Headers["X-Powered-By"], Is.EqualTo("ASP.NET"));
+			Assert.That(_result.Headers["Pragma"], Is.EqualTo("no-cache"));
+			Assert.That(_result.Headers["Content-Length"], Is.EqualTo("96,96"));
+			Assert.That(_result.Headers["Content-Type"], Is.EqualTo("text/html"));
+			Assert.That(_result.Headers["Expires"], Is.EqualTo("Sun, 03 Feb 2013 13:18:56 GMT"));
+			Assert.That(_result.Headers["Cache-control"], Is.EqualTo("no-store"));
+		}
+
+		[Test]
+		public void duplicated_http_headers_are_correct()
+		{
+			Assert.That(_result.Headers["Content-Length"], Is.EqualTo("96,96"));
+			
+		}
+
+	}
+}

--- a/src/ShiftIt.Unit.Tests/ShiftIt.Unit.Tests.csproj
+++ b/src/ShiftIt.Unit.Tests/ShiftIt.Unit.Tests.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Http\RequestBuilding\Lorem.cs" />
     <Compile Include="Http\RequestBuilding\SimplePost.cs" />
     <Compile Include="Http\RequestBuilding\SimpleGet.cs" />
+    <Compile Include="Http\Responses\WithDuplicatedHeaders.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Helpers\HttpSample.cs" />
     <Compile Include="Http\Responses\CompressedResponse.cs" />
@@ -66,6 +67,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Content Include="Helpers\duplicated_headers.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="Helpers\empty.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/src/ShiftIt/Http/HttpRequestBuilder.cs
+++ b/src/ShiftIt/Http/HttpRequestBuilder.cs
@@ -137,7 +137,7 @@ namespace ShiftIt.Http
 		{
 			Target = target;
 			_verb = verb;	
-			_url = target.ToString();
+			_url = target.AbsolutePath;
 			//_accept = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8";
             _accept = "*/*";
 		}

--- a/src/ShiftIt/Http/Internal/HttpReponse.cs
+++ b/src/ShiftIt/Http/Internal/HttpReponse.cs
@@ -32,7 +32,15 @@ namespace ShiftIt.Http.Internal
 
 		int ReportedBodyLength()
 		{
-			return Headers.ContainsKey("Content-Length") ? int.Parse(Headers["Content-Length"]):0;
+			return Headers.ContainsKey("Content-Length") ? int.Parse(GetContentLength()):0;
+		}
+
+		private string GetContentLength()
+		{
+			string[] contentLengthValues = Headers["Content-Length"].Split(',');
+			if (contentLengthValues.Length > 1)
+				return contentLengthValues[contentLengthValues.Length - 1];
+			return contentLengthValues[0];
 		}
 
 		Stream RestOfStreamDecompressed(Stream rawResponse)


### PR DESCRIPTION
Happens on some responses from Varnish. Split the values collected already, and use the last value.
