### PR TITLE
Better exception message when re-using the DataStream.

### DIFF
--- a/src/ShiftIt.Integration.Tests/PutDeleteAndCrossloadTests.cs
+++ b/src/ShiftIt.Integration.Tests/PutDeleteAndCrossloadTests.cs
@@ -24,7 +24,7 @@ namespace ShiftIt.Integration.Tests
 			_client = new HttpClient();
 			_uri_src = new Uri("http://encoderraid0.7digital.local/testing/files/hello.txt");
 			_uri_dst = new Uri("http://encoderraid0.7digital.local/testing/files/hello2.txt");
-			_putRq = new HttpRequestBuilder().Put(_uri_src).StringData("Hello, world").Build();
+			_putRq = new HttpRequestBuilder().Put(_uri_src).Build("Hello, world");
 			_getRq = new HttpRequestBuilder().Get(_uri_src).Build();
 			_deleteRq = new HttpRequestBuilder().Delete(_uri_src).Build();
 			_deleteRq2 = new HttpRequestBuilder().Delete(_uri_dst).Build();
@@ -54,7 +54,7 @@ namespace ShiftIt.Integration.Tests
 			using (var getTx = _client.Request(_getRq)) // get source
 			{
 				var putRq = new HttpRequestBuilder().Put(_uri_dst)
-					.Data(getTx.RawBodyStream, getTx.BodyReader.ExpectedLength).Build();
+					.Build(getTx.RawBodyStream, getTx.BodyReader.ExpectedLength);
 				using (var putTx = _client.Request(putRq)) // write out to dest
 				{
 					Assert.That(putTx.StatusClass, Is.EqualTo(StatusClass.Success));

--- a/src/ShiftIt.Integration.Tests/ShiftIt.Integration.Tests.csproj
+++ b/src/ShiftIt.Integration.Tests/ShiftIt.Integration.Tests.csproj
@@ -31,9 +31,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=2.6.2.12296, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>
+      <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/ShiftIt.Integration.Tests/packages.config
+++ b/src/ShiftIt.Integration.Tests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.2" targetFramework="net40" />
+  <package id="NUnit" version="2.6.3" targetFramework="net40" />
 </packages>

--- a/src/ShiftIt.Unit.Tests/Http/RequestBuilding/BasicAuthentication.cs
+++ b/src/ShiftIt.Unit.Tests/Http/RequestBuilding/BasicAuthentication.cs
@@ -25,7 +25,7 @@ namespace ShiftIt.Unit.Tests.Http.RequestBuilding
 		[Test]
 		public void correct_basic_authentication_string_is_used ()
 		{
-			Assert.That(_subject.Build().RequestHead().Lines(),
+			Assert.That(_subject.Build().RequestHead.Lines(),
 				Contains.Item("Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=="));
 		}
 		

--- a/src/ShiftIt.Unit.Tests/Http/RequestBuilding/CustomVerbs.cs
+++ b/src/ShiftIt.Unit.Tests/Http/RequestBuilding/CustomVerbs.cs
@@ -28,39 +28,39 @@ namespace ShiftIt.Unit.Tests.Http.RequestBuilding
 		[Test]
 		public void get_verb_is_given()
 		{
-			Assert.That(_subject.Build().RequestHead(), Is.StringStarting(_verb + " "));
+			Assert.That(_subject.Build().RequestHead, Is.StringStarting(_verb + " "));
 		}
 		
 		[Test]
 		public void http_version_is_given_as_1_1()
 		{
-			Assert.That(_subject.Build().RequestHead().Lines().First(), Is.StringEnding(" HTTP/1.1"));
+			Assert.That(_subject.Build().RequestHead.Lines().First(), Is.StringEnding(" HTTP/1.1"));
 		}
 
 		[Test]
 		public void request_path_is_given()
 		{
-			Assert.That(_subject.Build().RequestHead().Lines().First(), Is.StringContaining(_localTarget));
+			Assert.That(_subject.Build().RequestHead.Lines().First(), Is.StringContaining(_localTarget));
 		}
 
 		[Test]
 		public void default_headers_are_written_correctly()
 		{
-			Assert.That(_subject.Build().RequestHead().Lines(), Contains.Item("Host: www.example.com:80"));
-			Assert.That(_subject.Build().RequestHead().Lines(), Contains.Item("Accept: */*"));
+			Assert.That(_subject.Build().RequestHead.Lines(), Contains.Item("Host: www.example.com:80"));
+			Assert.That(_subject.Build().RequestHead.Lines(), Contains.Item("Accept: */*"));
 		}
 
 		[Test]
 		public void custom_headers_are_written_correctly()
 		{
-			Assert.That(_subject.Build().RequestHead().Lines(), Contains.Item("User-Agent: Phil's face"));
+			Assert.That(_subject.Build().RequestHead.Lines(), Contains.Item("User-Agent: Phil's face"));
 		}
 
 		[Test]
 		public void message_ends_in_two_sets_of_crlf_and_has_no_other_instance_of_crlfcrlf()
 		{
-			Assert.That(_subject.Build().RequestHead(), Is.StringEnding("\r\n\r\n"));
-			Assert.That(_subject.Build().RequestHead().CountOf("\r\n\r\n"), Is.EqualTo(1));
+			Assert.That(_subject.Build().RequestHead, Is.StringEnding("\r\n\r\n"));
+			Assert.That(_subject.Build().RequestHead.CountOf("\r\n\r\n"), Is.EqualTo(1));
 		}
 	}
 }

--- a/src/ShiftIt.Unit.Tests/Http/RequestBuilding/Headers.cs
+++ b/src/ShiftIt.Unit.Tests/Http/RequestBuilding/Headers.cs
@@ -14,54 +14,54 @@ namespace ShiftIt.Unit.Tests.Http.RequestBuilding
 		string _data;
 
 		[SetUp]
-		public void setup()
+		public void Setup()
 		{
 			_subject = new HttpRequestBuilder();
 			_target = new Uri("http://www.example.com/my/path");
 			_data = Lorem.Ipsum();
 
-			_subject.Post(_target).StringData(_data).SetHeader("User-Agent", "Phil's face");
+			_subject.Post(_target).SetHeader("User-Agent", "Phil's face").Build(_data);
 		}
 
 		[Test]
 		public void default_headers_are_written_correctly()
 		{
-			Assert.That(_subject.Build().RequestHead().Lines(), Contains.Item("Host: www.example.com:80"));
-			Assert.That(_subject.Build().RequestHead().Lines(), Contains.Item("Accept: */*"));
+			Assert.That(_subject.Build().RequestHead.Lines(), Contains.Item("Host: www.example.com:80"));
+			Assert.That(_subject.Build().RequestHead.Lines(), Contains.Item("Accept: */*"));
 		}
 
 		[Test]
 		public void custom_headers_are_written_correctly()
 		{
-			Assert.That(_subject.Build().RequestHead().Lines(), Contains.Item("User-Agent: Phil's face"));
+			Assert.That(_subject.Build().RequestHead.Lines(), Contains.Item("User-Agent: Phil's face"));
 		}
 
 		[Test]
 		public void can_add_several_values_to_a_header()
 		{
 			_subject.AddHeader("X-Plane", "one").AddHeader("X-Plane", "two").AddHeader("X-Plane", "two").AddHeader("X-Plane", "one");
-			Assert.That(_subject.Build().RequestHead().Lines(), Contains.Item("X-Plane: one,two"));
+			Assert.That(_subject.Build().RequestHead.Lines(), Contains.Item("X-Plane: one,two"));
 		}
 
 		[Test]
 		public void can_add_headers_with_field_name_being_case_insensitive()
 		{
 			_subject.AddHeader("X-Plane", "one").AddHeader("x-Plane", "two").AddHeader("X-plAne", "two");
-			Assert.That(_subject.Build().RequestHead().Lines(), Contains.Item("X-Plane: one,two"));
+			Assert.That(_subject.Build().RequestHead.Lines(), Contains.Item("X-Plane: one,two"));
 		}
 
 		[Test]
 		public void can_set_headers_with_field_name_being_case_insensitive()
 		{
 			_subject.SetHeader("X-Plane", "one").SetHeader("x-Plane", "three").SetHeader("X-plAne", "two");
-			Assert.That(_subject.Build().RequestHead().Lines(), Contains.Item("X-Plane: two"));
+			Assert.That(_subject.Build().RequestHead.Lines(), Contains.Item("X-Plane: two"));
 		}
 
 		[Test]
 		public void can_add_several_values_to_accept_encoding()
 		{
 			_subject.AddHeader("Accept-Encoding", "x-gzip").AddHeader("Accept-Encoding", "x-custom");
-			var headers = _subject.Build().RequestHead();
+			var headers = _subject.Build().RequestHead;
 
 			Assert.That(headers.Lines(), Contains.Item("Accept-Encoding: gzip,deflate,x-gzip,x-custom"));
 			Assert.That(headers.Lines().Count(x => x.StartsWith("Accept-Encoding:")), Is.EqualTo(1));
@@ -71,7 +71,7 @@ namespace ShiftIt.Unit.Tests.Http.RequestBuilding
 		public void can_add_several_values_to_accept()
 		{
 			_subject.Accept("application/json").AddHeader("Accept", "application/xml");
-			var headers = _subject.Build().RequestHead();
+			var headers = _subject.Build().RequestHead;
 
 			Assert.That(headers.Lines(), Contains.Item("Accept: application/json,application/xml"));
 			Assert.That(headers.Lines().Count(x => x.StartsWith("Accept:")), Is.EqualTo(1));
@@ -81,7 +81,7 @@ namespace ShiftIt.Unit.Tests.Http.RequestBuilding
 		public void set_header_removes_previous_value()
 		{
 			_subject.Accept("application/json").SetHeader("Accept", "application/xml").SetHeader("Accept", "text/html");
-			var headers = _subject.Build().RequestHead();
+			var headers = _subject.Build().RequestHead;
 
 			Assert.That(headers.Lines(), Contains.Item("Accept: text/html"));
 			Assert.That(headers.Lines().Count(x => x.StartsWith("Accept:")), Is.EqualTo(1));
@@ -91,9 +91,10 @@ namespace ShiftIt.Unit.Tests.Http.RequestBuilding
 		public void can_set_custom_host_header()
 		{
 			_subject.SetHeader("Host", "ww1.example.com:81");
-			var headers = _subject.Build().RequestHead();
+			var request = _subject.Build();
+			var headers = request.RequestHead;
 
-			Assert.That(((IHttpRequest)_subject).Target, Is.EqualTo(_target));
+			Assert.That(request.Target, Is.EqualTo(_target));
 			Assert.That(headers.Lines(), Contains.Item("Host: ww1.example.com:81"));
 			Assert.That(headers.Lines().Count(x => x.StartsWith("Host:")), Is.EqualTo(1));
 		}

--- a/src/ShiftIt.Unit.Tests/Http/RequestBuilding/SimpleGet.cs
+++ b/src/ShiftIt.Unit.Tests/Http/RequestBuilding/SimpleGet.cs
@@ -26,7 +26,7 @@ namespace ShiftIt.Unit.Tests.Http.RequestBuilding
 		[Test]
 		public void get_verb_is_given()
 		{
-			Assert.That(_subject.Build().RequestHead(), Is.StringStarting("GET "));
+			Assert.That(_subject.Build().RequestHead, Is.StringStarting("GET "));
 
 			Assert.That(_subject.Build().Verb, Is.EqualTo("GET"));
 		}
@@ -34,20 +34,20 @@ namespace ShiftIt.Unit.Tests.Http.RequestBuilding
 		[Test]
 		public void http_version_is_given_as_1_1()
 		{
-			Assert.That(_subject.Build().RequestHead().Lines().First(), Is.StringEnding(" HTTP/1.1"));
+			Assert.That(_subject.Build().RequestHead.Lines().First(), Is.StringEnding(" HTTP/1.1"));
 		}
 
 		[Test]
 		public void request_path_is_given()
 		{
-			Assert.That(_subject.Build().RequestHead().Lines().First(), Is.StringContaining(_localTarget));
+			Assert.That(_subject.Build().RequestHead.Lines().First(), Is.StringContaining(_localTarget));
 		}
 
 		[Test]
 		public void message_ends_in_two_sets_of_crlf_and_has_no_other_instance_of_crlfcrlf()
 		{
-			Assert.That(_subject.Build().RequestHead(), Is.StringEnding("\r\n\r\n"));
-			Assert.That(_subject.Build().RequestHead().CountOf("\r\n\r\n"), Is.EqualTo(1));
+			Assert.That(_subject.Build().RequestHead, Is.StringEnding("\r\n\r\n"));
+			Assert.That(_subject.Build().RequestHead.CountOf("\r\n\r\n"), Is.EqualTo(1));
 		}
 	}
 }

--- a/src/ShiftIt.Unit.Tests/Http/RequestBuilding/SimplePost.cs
+++ b/src/ShiftIt.Unit.Tests/Http/RequestBuilding/SimplePost.cs
@@ -11,56 +11,57 @@ namespace ShiftIt.Unit.Tests.Http.RequestBuilding
 	public class SimplePost
 	{
 		IHttpRequestBuilder _subject;
-		Uri target;
+		Uri _target;
 		string _data;
 		string _localTarget;
+		IHttpRequest _request;
 
 		[SetUp]
-		public void setup()
+		public void Setup()
 		{
 			_subject = new HttpRequestBuilder();
-			target = new Uri("http://www.example.com/my/path");
+			_target = new Uri("http://www.example.com/my/path");
 			_localTarget = "/my/path";
 			_data = Lorem.Ipsum();
 
-			_subject.Post(target).StringData(_data).SetHeader("User-Agent", "Phil's face");
+			_request = _subject.Post(_target).SetHeader("User-Agent", "Phil's face").Build(_data);
 		}
 
 		[Test]
 		public void post_verb_is_given()
 		{
-			Assert.That(_subject.Build().RequestHead(), Is.StringStarting("POST "));
+			Assert.That(_request.RequestHead, Is.StringStarting("POST "));
 		}
 
 		[Test]
 		public void content_length_is_given()
 		{
-			Assert.That(_subject.Build().RequestHead().Lines(), Contains.Item("Content-Length: "+_data.Length));
+			Assert.That(_request.RequestHead.Lines(), Contains.Item("Content-Length: " + _data.Length));
 		}
 
 		[Test]
 		public void content_is_written()
 		{
-			Assert.That(new StreamReader(_subject.Build().DataStream).ReadToEnd(), Is.EqualTo(_data));
+			Assert.That(new StreamReader(_request.DataStream).ReadToEnd(), Is.EqualTo(_data));
 		}
 
 		[Test]
 		public void http_version_is_given_as_1_1()
 		{
-			Assert.That(_subject.Build().RequestHead().Lines().First(), Is.StringEnding(" HTTP/1.1"));
+			Assert.That(_request.RequestHead.Lines().First(), Is.StringEnding(" HTTP/1.1"));
 		}
 
 		[Test]
 		public void request_path_is_given()
 		{
-			Assert.That(_subject.Build().RequestHead().Lines().First(), Is.StringContaining(_localTarget));
+			Assert.That(_request.RequestHead.Lines().First(), Is.StringContaining(_localTarget));
 		}
 
 		[Test]
 		public void message_ends_in_two_sets_of_crlf_and_has_no_other_instance_of_crlfcrlf()
 		{
-			Assert.That(_subject.Build().RequestHead(), Is.StringEnding("\r\n\r\n"));
-			Assert.That(_subject.Build().RequestHead().CountOf("\r\n\r\n"), Is.EqualTo(1));
+			Assert.That(_request.RequestHead, Is.StringEnding("\r\n\r\n"));
+			Assert.That(_request.RequestHead.CountOf("\r\n\r\n"), Is.EqualTo(1));
 		}
 	}
 }

--- a/src/ShiftIt.Unit.Tests/Http/RequestBuilding/StreamPut.cs
+++ b/src/ShiftIt.Unit.Tests/Http/RequestBuilding/StreamPut.cs
@@ -12,57 +12,59 @@ namespace ShiftIt.Unit.Tests.Http.RequestBuilding
 	public class StreamPut
 	{
 		IHttpRequestBuilder _subject;
-		Uri target;
+		Uri _target;
 		string _data;
 		Stream _dataStream;
 		string _localTarget;
+		IHttpRequest _request;
 
 		[SetUp]
-		public void setup()
+		public void Setup()
 		{
 			_subject = new HttpRequestBuilder();
-			target = new Uri("http://www.example.com/my/path");			_localTarget = "/my/path";
+			_target = new Uri("http://www.example.com/my/path");
+			_localTarget = "/my/path";
 			_data = Lorem.Ipsum();
 			_dataStream = new MemoryStream(Encoding.UTF8.GetBytes(_data));
 
-			_subject.Put(target).Data(_dataStream, _data.Length).SetHeader("User-Agent", "Phil's face");
+			_request = _subject.Put(_target).SetHeader("User-Agent", "Phil's face").Build(_dataStream, _data.Length);
 		}
 
 		[Test]
 		public void post_verb_is_given()
 		{
-			Assert.That(_subject.Build().RequestHead(), Is.StringStarting("PUT "));
+			Assert.That(_request.RequestHead, Is.StringStarting("PUT "));
 		}
 
 		[Test]
 		public void content_length_is_given()
 		{
-			Assert.That(_subject.Build().RequestHead().Lines(), Contains.Item("Content-Length: " + _data.Length));
+			Assert.That(_request.RequestHead.Lines(), Contains.Item("Content-Length: " + _data.Length));
 		}
 
 		[Test]
 		public void content_is_written()
 		{
-			Assert.That(new StreamReader(_subject.Build().DataStream).ReadToEnd(), Is.EqualTo(_data));
+			Assert.That(new StreamReader(_request.DataStream).ReadToEnd(), Is.EqualTo(_data));
 		}
 
 		[Test]
 		public void http_version_is_given_as_1_1()
 		{
-			Assert.That(_subject.Build().RequestHead().Lines().First(), Is.StringEnding(" HTTP/1.1"));
+			Assert.That(_request.RequestHead.Lines().First(), Is.StringEnding(" HTTP/1.1"));
 		}
 
 		[Test]
 		public void request_path_is_given()
 		{
-			Assert.That(_subject.Build().RequestHead().Lines().First(), Is.StringContaining(_localTarget));
+			Assert.That(_request.RequestHead.Lines().First(), Is.StringContaining(_localTarget));
 		}
 
 		[Test]
 		public void default_headers_are_written_correctly()
 		{
-			Assert.That(_subject.Build().RequestHead().Lines(), Contains.Item("Host: www.example.com:80"));
-			Assert.That(_subject.Build().RequestHead().Lines(), Contains.Item("Accept: */*"));
+			Assert.That(_request.RequestHead.Lines(), Contains.Item("Host: www.example.com:80"));
+			Assert.That(_request.RequestHead.Lines(), Contains.Item("Accept: */*"));
 		}
 	}
 }

--- a/src/ShiftIt.Unit.Tests/ShiftIt.Unit.Tests.csproj
+++ b/src/ShiftIt.Unit.Tests/ShiftIt.Unit.Tests.csproj
@@ -35,9 +35,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NSubstitute.1.6.1.0\lib\NET40\NSubstitute.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.2.12296, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>
+      <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/ShiftIt.Unit.Tests/packages.config
+++ b/src/ShiftIt.Unit.Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NSubstitute" version="1.6.1.0" targetFramework="net40" />
-  <package id="NUnit" version="2.6.2" targetFramework="net40" />
+  <package id="NUnit" version="2.6.3" targetFramework="net40" />
 </packages>

--- a/src/ShiftIt/Http/HttpClient.cs
+++ b/src/ShiftIt/Http/HttpClient.cs
@@ -28,7 +28,7 @@ namespace ShiftIt.Http
 		/// <summary>
 		/// Create a new HttpClient with a specified connection and parser
 		/// </summary>
-		internal HttpClient(IConnectableStreamSource conn, IHttpResponseParser parser)
+		private HttpClient(IConnectableStreamSource conn, IHttpResponseParser parser)
 		{
 			_conn = conn;
 			_parser = parser;
@@ -52,7 +52,7 @@ namespace ShiftIt.Http
 				: _conn.ConnectUnsecured(request.Target, Timeout);
 
 			var Tx = new StreamWriter(socket);
-			Tx.Write(request.RequestHead());
+			Tx.Write(request.RequestHead);
 			Tx.Flush();
 
 			if (request.DataStream != null)
@@ -82,7 +82,7 @@ namespace ShiftIt.Http
 					throw new HttpTransferException(getTx.Headers, loadRequest.Target, getTx.StatusCode);
 
 
-				var storeRq = storeRequest.Data(getTx.RawBodyStream, getTx.BodyReader.ExpectedLength).Build();
+				var storeRq = storeRequest.Build(getTx.RawBodyStream, getTx.BodyReader.ExpectedLength);
 				using (var storeRs = Request(storeRq))
 				{
 					if (storeRs.StatusClass != StatusClass.Success)
@@ -110,7 +110,7 @@ namespace ShiftIt.Http
 					throw new HttpTransferException(getTx.Headers, loadRequest.Target, getTx.StatusCode);
 
 				var hashStream = new HashingReadStream(getTx.RawBodyStream, hash);
-				var storeRq = storeRequest.Data(hashStream, getTx.BodyReader.ExpectedLength).Build();
+				var storeRq = storeRequest.Build(hashStream, getTx.BodyReader.ExpectedLength);
 				using (var storeRs = Request(storeRq))
 				{
 					if (storeRs.StatusClass != StatusClass.Success)

--- a/src/ShiftIt/Http/IHttpRequest.cs
+++ b/src/ShiftIt/Http/IHttpRequest.cs
@@ -21,7 +21,7 @@ namespace ShiftIt.Http
 		/// <summary>
 		/// Headers
 		/// </summary>
-		string RequestHead();
+		string RequestHead { get; }
 
 		/// <summary>
 		/// Body data stream

--- a/src/ShiftIt/Http/IHttpRequestBuilder.cs
+++ b/src/ShiftIt/Http/IHttpRequestBuilder.cs
@@ -59,25 +59,25 @@ namespace ShiftIt.Http
 		IHttpRequestBuilder Accept(string mimeTypes);
 
 		/// <summary>
-		/// Provide a data stream for the request. It will be sent to the target resource's
-		/// hosting server.
-		/// </summary>
-		/// <param name="stream">Data stream</param>
-		/// <param name="length">Length of data. Must be provided.</param>
-		IHttpRequestBuilder Data(Stream stream, long length);
-
-		/// <summary>
-		/// Provide string data for the request. It will be sent to the target resource's
-		/// hosting server.
-		/// </summary>
-		IHttpRequestBuilder StringData(string data);
-
-		/// <summary>
 		/// Provide basic authentication details for the target resource.
 		/// WARNING: this will be sent in the clear. Use only in internal networks
 		/// or over SSL connections.
 		/// </summary>
 		IHttpRequestBuilder BasicAuthentication(string userName, string password);
+
+		/// <summary>
+		/// Build the request, providing a data stream for the request. It will be sent to the target resource's
+		/// hosting server.
+		/// </summary>
+		/// <param name="stream">Data stream</param>
+		/// <param name="length">Length of data. Must be provided.</param>
+		IHttpRequest Build(Stream stream, long length);
+
+		/// <summary>
+		/// Build the request, providing string data for the request. It will be sent to the target resource's
+		/// hosting server.
+		/// </summary>
+		IHttpRequest Build(string data);
 
 		/// <summary>
 		/// Build the request

--- a/src/ShiftIt/Properties/AssemblyInfo.cs
+++ b/src/ShiftIt/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
-[assembly: AssemblyVersion("1.3.1.0")]
-[assembly: AssemblyFileVersion("1.3.1.0")]
+[assembly: AssemblyVersion("1.4.0.0")]
+[assembly: AssemblyFileVersion("1.4.0.0")]
 [assembly: AssemblyCompany("i-e-b")]
 [assembly: AssemblyDescription("Collection of low-level HTTP and FTP file transfer tools")]

--- a/src/ShiftIt/ShiftIt.nuspec
+++ b/src/ShiftIt/ShiftIt.nuspec
@@ -9,7 +9,7 @@
     <projectUrl>https://github.com/i-e-b/Shift-it</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>$description$</description>
-    <releaseNotes>Support for overriding Accept, Accept-Encoding and Host headers. Case-insensitive handling of header field names.</releaseNotes>
+    <releaseNotes>Changed data stream approach to avoid confusing failure scenarios.</releaseNotes>
     <copyright>Copyright 2013</copyright>
     <tags>http ftp sockets client</tags>
   </metadata>


### PR DESCRIPTION
Previously, this would end in a timeout, because shiftit would try to write a stream that was positioned beyond its end.

If that looks ok, I'll create a .nuget and upload it.
