### PR TITLE
Implementing IRequestBuilder.Build(new {batchId=123});

### DIFF
--- a/src/ShiftIt.Unit.Tests/Http/RequestBuilding/ObjectToRequestStreamConverterTest.cs
+++ b/src/ShiftIt.Unit.Tests/Http/RequestBuilding/ObjectToRequestStreamConverterTest.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using ShiftIt.Http;
+using ShiftIt.Internal.Http;
+using System.IO;
+using System.Text;
+using System.Web;
+
+namespace ShiftIt.Unit.Tests.Http.RequestBuilding
+{
+	[TestFixture]
+	public class ObjectToRequestStreamConverterTest
+	{
+		IObjectToRequestStreamConverter _subject;
+
+		[SetUp]
+		public void SetUp()
+		{
+			_subject = new ObjectToRequestStreamConverter();
+		}
+
+		private static IEnumerable<TestCaseData> TestData
+		{
+			get
+			{
+				yield return new TestCaseData(new { }, string.Empty);
+				yield return new TestCaseData(new { batchId = 1234 }, "batchId=1234");
+				yield return new TestCaseData(new { batchId = 1234, isComplete = false }, "batchId=1234&isComplete=False");
+				yield return new TestCaseData(new { q = (string)null }, "q=");
+				yield return new TestCaseData(new { i1 = 12345, i2 = 0.898, i3 = 8.9900m }, "i1=12345&i2=0.898&i3=8.9900");
+
+				yield return new TestCaseData(new object[]
+				{
+					new { batchId = 1234, isComplete = false },
+					new { batchId = 134, isComplete = true },
+					new { batchId = 14, otherId = true }
+				}, "batchId=1234&isComplete=False&batchId=134&isComplete=True&batchId=14&otherId=True");
+
+				yield return
+					new TestCaseData(new
+					{
+						Name_ = "Jonathan Doe",
+						Age = "23",
+						Formula = "a + b == 13%!_-.~&"
+					},
+						"Name_=Jonathan+Doe&Age=23&Formula=a+%2B+b+%3D%3D+13%25%21_-.~%26");
+
+				yield return new TestCaseData(new
+					{
+						// ព្រះ​ពុទ្ឋឃោសា
+						v = "\u1796\u17d2\u179a\u17c7\u200b\u1796\u17bb\u1791\u17d2\u178b\u1783\u17c4\u179f\u17b6"
+					},
+					"v=%E1%9E%96%E1%9F%92%E1%9E%9A%E1%9F%87%E2%80%8B%E1%9E%96%E1%9E%BB%E1%9E%91%E1%9F%92%E1%9E%8B%E1%9E%83%E1%9F%84%E1%9E%9F%E1%9E%B6");
+
+				yield return new TestCaseData(new
+					{
+						\u1796\u17d2\u179a\u17c7_\u1796\u17bb\u1791\u17d2\u178b\u1783\u17c4\u179f\u17b6 = "1"
+					},
+					"%E1%9E%96%E1%9F%92%E1%9E%9A%E1%9F%87_%E1%9E%96%E1%9E%BB%E1%9E%91%E1%9F%92%E1%9E%8B%E1%9E%83%E1%9F%84%E1%9E%9F%E1%9E%B6=1");
+			}
+		}
+
+		[Test]
+		[TestCaseSource("TestData")]
+		public void Should_format_data_as_expected(object actual, string expected)
+		{
+			var data = (MemoryStream)_subject.ConvertToStream(actual);
+			var stringData = Encoding.ASCII.GetString(data.ToArray());
+			Assert.That(stringData, Is.EqualTo(expected));
+		}
+
+		[Test]
+		public void Request_builder_throws_when_content_type_for_data_doesnt_match()
+		{
+			var exc = Assert.Throws<ArgumentException>(
+				() => new HttpRequestBuilder().Put(new Uri("http://test")).Build(new {}));
+			Assert.That(exc, Has.Message.EqualTo(
+				"Automated data serialisation is only supported for Content-Type:application/x-www-form-urlencoded."));
+		}
+
+		[Test]
+		public void Request_builder_doesnt_throw_when_content_type_for_data_is_correct()
+		{
+			Assert.DoesNotThrow(
+				() => new HttpRequestBuilder().Put(new Uri("http://test")).AddHeader("Content-Type", "application/x-www-form-urlencoded")
+					.Build(new { }));
+		}
+	}
+}

--- a/src/ShiftIt.Unit.Tests/ShiftIt.Unit.Tests.csproj
+++ b/src/ShiftIt.Unit.Tests/ShiftIt.Unit.Tests.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Http\RequestBuilding\CustomVerbs.cs" />
     <Compile Include="Http\RequestBuilding\Headers.cs" />
     <Compile Include="Http\RequestBuilding\HttpsDetection.cs" />
+    <Compile Include="Http\RequestBuilding\ObjectToRequestStreamConverterTest.cs" />
     <Compile Include="Http\RequestBuilding\StreamPut.cs" />
     <Compile Include="Http\RequestBuilding\Lorem.cs" />
     <Compile Include="Http\RequestBuilding\SimplePost.cs" />

--- a/src/ShiftIt/Http/HttpRequestBuilder.cs
+++ b/src/ShiftIt/Http/HttpRequestBuilder.cs
@@ -2,7 +2,9 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text;
+using ShiftIt.Internal.Http;
 
 namespace ShiftIt.Http
 {
@@ -127,6 +129,26 @@ namespace ShiftIt.Http
 			var bytes = Encoding.UTF8.GetBytes(data);
 			var dataLength = bytes.Length;
 			return new HttpRequest(_target, _verb, new MemoryStream(bytes), dataLength, RequestHead(dataLength));
+		}
+
+		/// <summary>
+		/// Build the request, providing object data for the request. It will be sent to the target resource's
+		/// hosting server.
+		/// </summary>
+		/// <example><code>
+		/// // sends out "targetId=142&amp;value=Hello%2C+Jim"
+		/// builder.Build(new {targetId = 142, value = "Hello, Jim" });
+		/// </code></example>
+		public IHttpRequest Build(object data)
+		{
+			if (!_headers.ContainsKey("Content-Type")
+				|| _headers["Content-Type"].Single() != "application/x-www-form-urlencoded")
+				throw new ArgumentException(
+					"Automated data serialisation is only supported for Content-Type:application/x-www-form-urlencoded.");
+
+			var dataStream = new ObjectToRequestStreamConverter().ConvertToStream(data);
+			var dataLength = dataStream.Length;
+			return new HttpRequest(_target, _verb, dataStream, dataLength, RequestHead(dataLength));
 		}
 
 		/// <summary>

--- a/src/ShiftIt/Http/IHttpRequestBuilder.cs
+++ b/src/ShiftIt/Http/IHttpRequestBuilder.cs
@@ -80,6 +80,16 @@ namespace ShiftIt.Http
 		IHttpRequest Build(string data);
 
 		/// <summary>
+		/// Build the request, providing object data for the request. It will be sent to the target resource's
+		/// hosting server.
+		/// </summary>
+		/// <example><code>
+		/// // sends out "targetId=142&amp;value=Hello%2C+Jim"
+		/// builder.Build(new {targetId = 142, value = "Hello, Jim" });
+		/// </code></example>
+		IHttpRequest Build(object data);
+
+		/// <summary>
 		/// Build the request
 		/// </summary>
 		IHttpRequest Build();

--- a/src/ShiftIt/Internal/Http/IObjectToRequestStreamConverter.cs
+++ b/src/ShiftIt/Internal/Http/IObjectToRequestStreamConverter.cs
@@ -1,0 +1,9 @@
+﻿using System.IO;
+
+namespace ShiftIt.Internal.Http
+{
+	public interface IObjectToRequestStreamConverter
+	{
+		Stream ConvertToStream(object value);
+	}
+}

--- a/src/ShiftIt/Internal/Http/ObjectToRequestStreamConverter.cs
+++ b/src/ShiftIt/Internal/Http/ObjectToRequestStreamConverter.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections;
+using System.ComponentModel;
+using System.Globalization;
+using System.IO;
+using System.Text;
+
+namespace ShiftIt.Internal.Http
+{
+	/// <summary>
+	/// Constructs POST body stream for application/x-www-form-urlencoded requests.
+	/// </summary>
+	public class ObjectToRequestStreamConverter : IObjectToRequestStreamConverter
+	{
+		private const byte equals = (byte) '=';
+		private const byte and = (byte) '&';
+		private const byte plus = (byte)'+';
+		private const string unreservedChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.~";
+
+		/// <summary>
+		/// Does the actual work using <see cref="TypeDescriptor"/>.
+		/// </summary>
+		/// <param name="value">object to encode</param>
+		/// <returns>POST body stream, rewound to the beginning.</returns>
+		public Stream ConvertToStream(object value)
+		{
+			var result = new MemoryStream();
+			var enumerable = value as IEnumerable;
+			if (enumerable != null)
+			{
+				var firstParameter = true;
+				foreach (var enumerableValue in enumerable)
+				{
+					WriteValueObject(enumerableValue, firstParameter, result);
+					firstParameter = false;
+				}
+			}
+			else
+			{
+				WriteValueObject(value, true, result);
+			}
+
+			result.Position = 0;
+			return result;
+		}
+
+		private void WriteValueObject(object value, bool firstParameter, MemoryStream result)
+		{
+			var properties = TypeDescriptor.GetProperties(value);
+			foreach (PropertyDescriptor property in properties)
+			{
+				WriteProperty(value, firstParameter, result, property);
+				firstParameter = false;
+			}
+		}
+
+		private void WriteProperty(object valueProvider, bool firstParameter, MemoryStream result, PropertyDescriptor property)
+		{
+			if (!firstParameter)
+				result.WriteByte(and);
+
+			UrlEncodeAndWrite(property.Name, result);
+			result.WriteByte(@equals);
+
+			var propertyValue = property.GetValue(valueProvider);
+			var formattableValue = propertyValue as IFormattable;
+
+			string stringValue = null;
+			if (formattableValue != null)
+				stringValue = formattableValue.ToString(null, CultureInfo.InvariantCulture);
+			else if (propertyValue != null)
+				stringValue = propertyValue.ToString();
+
+			if (stringValue != null)
+			{
+				UrlEncodeAndWrite(stringValue, result);
+			}
+		}
+
+		// RFC:  http://www.w3.org/TR/html5/forms.html#application/x-www-form-urlencoded-encoding-algorithm
+		private void UrlEncodeAndWrite(string value, MemoryStream memoryStream)
+		{
+			foreach (char symbol in value)
+			{
+				if (unreservedChars.IndexOf(symbol) != -1)
+				{
+					memoryStream.WriteByte((byte)symbol);
+				}
+				else if (symbol == ' ')
+				{
+					memoryStream.WriteByte(plus);
+				}
+				else if (symbol < 255)
+				{
+					var encodedValue = Encoding.ASCII.GetBytes(String.Format("%{0:X2}", (byte)symbol));
+					memoryStream.Write(encodedValue, 0, encodedValue.Length);
+				}
+				else
+				{
+					var bytes = Encoding.UTF8.GetBytes(new[] { symbol });
+					foreach (var @byte in bytes)
+					{
+						var encodedValue = Encoding.ASCII.GetBytes(String.Format("%{0:X2}", @byte));
+						memoryStream.Write(encodedValue, 0, encodedValue.Length);
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/ShiftIt/Properties/AssemblyInfo.cs
+++ b/src/ShiftIt/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
-[assembly: AssemblyVersion("1.4.2.0")]
-[assembly: AssemblyFileVersion("1.4.2.0")]
+[assembly: AssemblyVersion("1.4.3.0")]
+[assembly: AssemblyFileVersion("1.4.3.0")]
 [assembly: AssemblyCompany("i-e-b")]
 [assembly: AssemblyDescription("Collection of low-level HTTP and FTP file transfer tools")]

--- a/src/ShiftIt/ShiftIt.csproj
+++ b/src/ShiftIt/ShiftIt.csproj
@@ -52,6 +52,8 @@
     <Compile Include="Internal\Http\IHttpResponseParser.cs" />
     <Compile Include="Http\StatusClass.cs" />
     <Compile Include="Http\TimeoutException.cs" />
+    <Compile Include="Internal\Http\IObjectToRequestStreamConverter.cs" />
+    <Compile Include="Internal\Http\ObjectToRequestStreamConverter.cs" />
     <Compile Include="Internal\Streaming\HttpChunkedResponseStream.cs" />
     <Compile Include="Internal\Streaming\HttpSingleResponseStream.cs" />
     <Compile Include="Internal\Socket\IConnectableStreamSource.cs" />

--- a/src/ShiftIt/ShiftIt.nuspec
+++ b/src/ShiftIt/ShiftIt.nuspec
@@ -9,7 +9,7 @@
     <projectUrl>https://github.com/i-e-b/Shift-it</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>$description$</description>
-    <releaseNotes>Increased default buffer size.</releaseNotes>
+    <releaseNotes>Added convenience overload to IHttpRequestBuilder.Build()</releaseNotes>
     <copyright>Copyright 2013</copyright>
     <tags>http ftp sockets client</tags>
   </metadata>


### PR DESCRIPTION
As suggested by @willm , I've implemented a new overload to Build() that allows usage like this:

```
builder.Build(new {targetId = 142, value = "Hello, Jim" });
```

to send out HTTP Body of `targetId=142&value=Hello%2C+Jim`
